### PR TITLE
Change alphabet-related lists to `ol`s

### DIFF
--- a/_tmpl/css/ala-main.css
+++ b/_tmpl/css/ala-main.css
@@ -153,7 +153,7 @@ h2{margin:27px
 0 12px;font-size:18px;line-height:30px;font-family:"Franklin ITC Pro Bold",sans-serif;font-weight:normal;font-style:normal}.secondary-column h2[data-display-letter]:after{content:" (" attr(data-display-letter) ")"}.home-page .secondary-column h2,
 .issue-page .secondary-column
 h2{margin-top:0}.alphabits{position:relative;height:24px;margin-bottom:18px;overflow:hidden}.alphabits
-ul{position:absolute;top:0;left:30px;-webkit-transition:all 200ms ease-in;-moz-transition:all 200ms ease-in;-o-transition:all 200ms ease-in;-ms-transition:all 200ms ease-in;transition:all 200ms ease-in;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;-ms-backface-visibility:hidden}.alphabits ul
+ol{position:absolute;top:0;left:30px;-webkit-transition:all 200ms ease-in;-moz-transition:all 200ms ease-in;-o-transition:all 200ms ease-in;-ms-transition:all 200ms ease-in;transition:all 200ms ease-in;-webkit-backface-visibility:hidden;-moz-backface-visibility:hidden;-ms-backface-visibility:hidden}.alphabits ol
 li{display:inline-block}.alphabits
 a{display:inline-block;vertical-align:top;width:24px;height:24px;margin-right:5px;font-size:18px;line-height:24px;font-family:"Franklin ITC Pro Bold",sans-serif;font-weight:normal;font-style:normal;text-align:center;background:#eee;border-radius:5px;color:#222;text-transform:uppercase;-webkit-transition:background 200ms ease-in;-moz-transition:background 200ms ease-in;-o-transition:background 200ms ease-in;-ms-transition:background 200ms ease-in;transition:background 200ms ease-in}.alphabits a:hover{text-decoration:none;background:#ddd;cursor:pointer}.alphabits
 a.arrow{position:absolute;top:-1px;left:-1px;font-size:14px;line-height:28px;border:1px

--- a/_tmpl/patterns/alpha-target.html
+++ b/_tmpl/patterns/alpha-target.html
@@ -1,4 +1,4 @@
-<ul id="alpha-target" class="secondary-nav compressed alpha-container">
+<ol id="alpha-target" class="secondary-nav compressed alpha-container">
 	<li data-letter="a"><a href="/author/lealea">Lea Alcantara</a></li>
 	<li data-letter="a"><a href="/author/deanallen"> Dean Allen</a></li>
 	<li data-letter="a"><a href="/author/johnallsopp"> John Allsopp</a></li>
@@ -10,4 +10,4 @@
 	<li data-letter="a"><a href="/author/chrisarmstrong">Chris Armstrong</a></li>
 	<li data-letter="a"><a href="/author/lancearthur"> Lance Arthur</a></li>
 	<li data-letter="a"><a href="/author/farukates">Faruk Ateş</a></li>
-</ul>
+</ol>

--- a/_tmpl/patterns/alphabits.html
+++ b/_tmpl/patterns/alphabits.html
@@ -1,5 +1,5 @@
-<nav id="alphabits" class="alphabits">				
-	<ul>
+<nav id="alphabits" class="alphabits">
+	<ol>
 		<li><a data-alphabit="a">a</a></li>
 		<li><a data-alphabit="b">b</a></li>
 		<li><a data-alphabit="c">c</a></li>
@@ -26,7 +26,7 @@
 		<li><a data-alphabit="x">x</a></li>
 		<li><a data-alphabit="y">y</a></li>
 		<li><a data-alphabit="z">z</a></li>
-	</ul>
+	</ol>
 	
 	<a id="previous-letters" class="arrow left">◀</a>
 	<a id="next-letters" class="arrow right">▶</a>


### PR DESCRIPTION
"Alphabet" lists are, in fact, ordered alphabetically and should be marked up as such.

This does, however, require a change in the actual stylesheet, which was done in alistapart/AListApart#54
