### PR TITLE
load-grunt-tasks For Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,9 @@
 'use strict';
 
 module.exports = function(grunt) {
+
+	require('load-grunt-tasks')(grunt);
+
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		concat: {
@@ -104,15 +107,6 @@ module.exports = function(grunt) {
 			}
 		}
 	});
-
-	grunt.loadNpmTasks('grunt-contrib-uglify');
-	grunt.loadNpmTasks('grunt-contrib-cssmin');
-	grunt.loadNpmTasks('grunt-contrib-jshint');
-	grunt.loadNpmTasks('grunt-contrib-concat');
-	grunt.loadNpmTasks('grunt-contrib-clean');
-	grunt.loadNpmTasks('grunt-contrib-copy');
-	grunt.loadNpmTasks('grunt-chmod');
-	grunt.loadNpmTasks('grunt-contrib-watch');
 
 	grunt.registerTask('cleanup', ['chmod:writeable', 'clean', 'chmod:readonly']);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-chmod": "~1.0.3",
     "grunt-contrib-uglify": "~0.3.2",
-    "grunt-contrib-jshint": "~0.8.0"
+    "grunt-contrib-jshint": "~0.8.0",
+    "load-grunt-tasks": "~0.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Reduce duplication of list of grunt tasks. Previously, the same list existed in both
package.json and Gruntfile.js. Code and author for load-grunt-tasks.js:

http://travis-ci.org/sindresorhus/load-grunt-tasks

As per the author's readme.md, replace in Gruntfile.js, in this instance:

grunt.loadNpmTasks('grunt-contrib-uglify');
grunt.loadNpmTasks('grunt-contrib-cssmin');
grunt.loadNpmTasks('grunt-contrib-jshint');
grunt.loadNpmTasks('grunt-contrib-concat');
grunt.loadNpmTasks('grunt-contrib-clean');
grunt.loadNpmTasks('grunt-contrib-copy');
grunt.loadNpmTasks('grunt-chmod');
grunt.loadNpmTasks('grunt-contrib-watch');

with:

require('load-grunt-tasks')(grunt);

At which point, bob's your uncle and the grunt command works as expected.
